### PR TITLE
Upgrade RunDataset.sh to handle both singlefiles and full datasets

### DIFF
--- a/RunDataset.sh
+++ b/RunDataset.sh
@@ -1,36 +1,74 @@
 #!/usr/bin/bash
 
-# read the input parameters
-# $1: the executable (for example: ./Data_Analysis)
-# $2: the path of the dataset
-# $3: the path of the output folder 
-# $4: the cross-section of the dataset
-# $5: IntLumi of the dataset
-# $6: the signal/bkgd flag
-# $7: proxy path
-
-# exit if cd fails
-export X509_USER_PROXY=/afs/cern.ch/user/g/gdamolin/private/x509up_u151129
-#voms-proxy-info -all
-voms-proxy-info -all -file /afs/cern.ch/user/g/gdamolin/private/x509up_u151129
-
-echo "Before"
-echo "$2"
-echo "This is my argument"
-echo "$1 $3 $4 $5 $6"
-echo "These are the rest"
-
-#datafiles=$(dasgoclient -query="file dataset=root://cms-xrd-global.cern.ch///store/mc/RunIISummer20UL18NanoAODv2$2")
-
-datafiles=$(dasgoclient -query="file dataset=$2")
-
-echo $datafiles
-
-for file in $datafiles; do
-    #create the name of the output file: strip the path
-    filename=$(echo $file | sed 's|\(^.*/\)\([a-z,A-Z,0-9,-]*\).root$|\2|')
-    echo $filename
-    ofilename=$3/$filename"_MA".root
-    echo "$1 root://cms-xrd-global.cern.ch//$file $ofilename $4 $5 $6" 
-    "$1 root://cms-xrd-global.cern.ch//$file $ofilename $4 $5 $6" 
+# parse the command line arguments
+# -e the executable (for example: ./Data_Analysis)
+# -d the dataset name as in DAS
+# -o the path of the output folder 
+# -x the cross-section of the dataset
+# -l IntLumi of the dataset
+# -s the signal/bkgd flag
+# -p proxy path
+X509_USER_PROXY=/afs/cern.ch/user/g/gdamolin/private/x509up_u151129
+while getopts "e:d:o:x:l:s:p:" opt; do
+    case "$opt" in
+        e) EXE=$OPTARG
+            ;;
+        d) DATASET=$OPTARG
+            ;;
+        o) OUTPATH=$OPTARG
+            ;;
+        x) XSEC=$OPTARG
+            ;;
+        l) LUMI=$OPTARG
+            ;;
+        s) SIGNAL=$OPTARG
+            ;;
+        p) X509_USER_PROXY=$OPTARG
+            ;;
+    esac
 done
+
+
+#define a simple function to test the inputs are available
+test_input () {
+  echo "$1 = $2"
+  if [ -z "$2" ]
+  then
+      echo "$1 is empty, use option -$3 to define... quitting"
+      exit -1
+  fi
+}
+test_input "Executable" "$EXE" "e"
+test_input "Dataset" "$DATASET" "d"
+test_input "Output path" "$OUTPATH" "o"
+test_input "Cross section" "$XSEC" "x"
+test_input "Integ. luminosity" "$LUMI" "l"
+test_input "Signal" "$SIGNAL" "s"
+test_input "Path to proxy" "$X509_USER_PROXY" "p"
+
+#now test what has been asked to analyze
+#1. a single file run executable
+#2. a full dataset, create a condor file
+if [[ "$DATASET" == *"root://"* ]]; then
+
+  echo "Dataset is already a single file, will run executable for it"
+
+  filename=$DATASET
+  ofilename=${OUTPATH}/$filename"_MA".root
+  echo "${EXE} $filename $ofilename ${XSEC} ${LUMI} ${SIGNAL}" 
+
+else
+
+  echo "Using dasgoclient to list files and create submission jobs"
+
+  datafiles=`dasgoclient -query="file dataset=${DATASET}"`
+  jobdescription="jobdescription.txt"
+  rm ${jobdescription}
+  for file in ${datafiles[@]}; do
+      echo "-e ${EXE} -d root://cms-xrd-global.cern.ch//${file} -o ${OUTPATH} -x ${XSEC} -l ${LUMI} -s ${SIGNAL} -p ${X509_USER_PROXY}" >> ${jobdescription} 
+  done
+  echo "Use ${jobdescription} with your condor file"
+
+fi
+
+


### PR DESCRIPTION
I have changed the shell script slightly to:
- parse command line options instead of simple argument listing
- test if the options are correctly filled
- handle single files or full datasets
For full datasets a jobdescription.txt file is created on the fly with the arguments to be passed on to the condor submission script or ran locally. I didn't submit anything to condor, that should be the next step. But locally it runs fine with
```
sh RunDataset.sh -e test -d /DYJetsToLL_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv2-106X_upgrade2018_realistic_v15_L1v1-v1/NANOAODSIM -o /tmp/psilva -x 1 -l 1 -s true -p /tmp/x509up_u100724
```
or 
```
sh RunDataset.sh -e test -d root://cms-xrd-global.cern.ch///store/mc/RunIISummer20UL18NanoAODv2/DYJetsToLL_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/NANOAODSIM/106X_upgrade2018_realistic_v15_L1v1-v1/130000/6E2A3FD3-C3FD-5A4C-B97C-58DC2C0A0A60.root -o /tmp/psilva -x 1 -l 1 -s true -p /tmp/x509up_u100724
```